### PR TITLE
Add .NET SDK implementation for `mcpd` with NuGet packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xml
+
+# Auto-generated proto files.
+**/proto/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,190 @@
-# mcpd-plugins-sdk-dotnet
-mcpd plugin SDK for .NET
+# `mcpd` plugins SDK for .NET
+
+.NET SDK for developing `mcpd` middleware plugins.
+
+## Overview
+
+This SDK provides .NET types and gRPC interfaces for building middleware plugins that integrate with `mcpd`.
+Plugins can process HTTP requests and responses, implementing capabilities like authentication, rate limiting,
+content transformation, and observability.
+
+## Installation
+
+Add the package reference to your project:
+
+```bash
+dotnet add package MozillaAI.Mcpd.Plugins.Sdk
+```
+
+Or add it directly to your `.csproj` file:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="MozillaAI.Mcpd.Plugins.Sdk" Version="0.0.1" />
+</ItemGroup>
+```
+
+## Usage
+
+The SDK provides the `PluginServer` helper and `BasePlugin` class to minimize boilerplate.
+
+### Example Plugin
+
+```csharp
+using Google.Protobuf.WellKnownTypes;
+using MozillaAI.Mcpd.Plugins.V1;
+
+public class MyPlugin : BasePlugin
+{
+    public override Task<Metadata> GetMetadata(Empty request, Grpc.Core.ServerCallContext context)
+    {
+        return Task.FromResult(new Metadata
+        {
+            Name = "my-plugin",
+            Version = "1.0.0",
+            Description = "Example plugin that does something useful"
+        });
+    }
+
+    public override Task<Capabilities> GetCapabilities(Empty request, Grpc.Core.ServerCallContext context)
+    {
+        return Task.FromResult(new Capabilities
+        {
+            Flows = { FlowConstants.FlowRequest }
+        });
+    }
+
+    public override Task<HTTPResponse> HandleRequest(HTTPRequest request, Grpc.Core.ServerCallContext context)
+    {
+        var response = new HTTPResponse
+        {
+            Continue = true,
+            StatusCode = 0,
+            Body = request.Body
+        };
+
+        foreach (var header in request.Headers)
+        {
+            response.Headers.Add(header.Key, header.Value);
+        }
+
+        return Task.FromResult(response);
+    }
+}
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        return await PluginServer.Serve<MyPlugin>(args);
+    }
+}
+```
+
+The `BasePlugin` class provides default implementations for all plugin methods. Override only the methods you need:
+
+| Method | Default Behavior |
+|--------|------------------|
+| `CheckHealth()` | Returns OK |
+| `CheckReady()` | Returns OK |
+| `Configure()` | No-op |
+| `Stop()` | No-op |
+| `HandleRequest()` | Pass through unchanged |
+| `HandleResponse()` | Pass through unchanged |
+| `GetMetadata()` | Returns empty (should be overridden) |
+| `GetCapabilities()` | Returns empty (should be overridden) |
+
+## Running Your Plugin
+
+Build and run your plugin:
+
+```bash
+dotnet build
+dotnet run -- --address /tmp/my-plugin.sock --network unix
+```
+
+Or for TCP:
+
+```bash
+dotnet run -- --address localhost:50051 --network tcp
+```
+
+## Proto Versioning
+
+The SDK automatically downloads proto definitions from [mcpd-proto](https://github.com/mozilla-ai/mcpd-proto) at build time.
+
+Current proto version: **v0.0.2**
+
+| Version Type | Description |
+|--------------|-------------|
+| API Version | `plugins/v1/` (in proto repo) maps to `MozillaAI.Mcpd.Plugins.V1` namespace (in SDK) |
+| Release Version | Proto repo tags like `v0.0.1`, `v0.0.2`, etc. |
+| SDK Version | This repo's tags track SDK releases and may differ from proto versions |
+
+To update the proto version, modify the `<ProtoVersion>` property in the SDK `.csproj` file.
+
+## Repository Structure
+
+```
+mcpd-plugins-sdk-dotnet/
+├── README.md                       # This file.
+├── LICENSE                         # Apache 2.0 license.
+├── mcpd-plugins-sdk-dotnet.sln     # Solution file.
+├── .gitignore                      # Ignores proto/ and bin/obj directories.
+├── src/
+│   └── MozillaAI.Mcpd.Plugins.Sdk/
+│       ├── MozillaAI.Mcpd.Plugins.Sdk.csproj  # SDK project file.
+│       ├── BasePlugin.cs                       # BasePlugin helper class.
+│       ├── PluginServer.cs                     # PluginServer helper class.
+│       ├── FlowConstants.cs                    # Flow enum constants.
+│       └── proto/                              # Downloaded protos (auto-generated, gitignored).
+└── examples/
+    └── MyPlugin/
+        ├── MyPlugin.csproj         # Example plugin project.
+        └── Program.cs              # Example plugin implementation.
+```
+
+## For SDK Maintainers
+
+### Prerequisites
+
+- .NET 9.0 SDK or later
+- Protocol Buffer Compiler (protoc) - automatically installed via `Grpc.Tools` NuGet package
+
+### Building the SDK
+
+```bash
+dotnet build
+```
+
+The proto files are automatically downloaded during the build process via the `FetchProto` target defined in the `.csproj` file.
+
+### Running the Example
+
+```bash
+cd examples/MyPlugin
+dotnet run -- --address /tmp/my-plugin.sock --network unix
+```
+
+### Updating Proto Version
+
+1. Edit the `<ProtoVersion>` property in `src/MozillaAI.Mcpd.Plugins.Sdk/MozillaAI.Mcpd.Plugins.Sdk.csproj`
+2. Run `dotnet clean` and `dotnet build`
+3. Commit the updated project file
+
+## Health Checking
+
+The SDK follows [gRPC Health Checking Protocol](https://grpc.github.io/grpc/core/md_doc_health-checking.html) conventions:
+
+```protobuf
+rpc CheckHealth(google.protobuf.Empty) returns (google.protobuf.Empty);
+rpc CheckReady(google.protobuf.Empty) returns (google.protobuf.Empty);
+```
+
+## License
+
+Apache 2.0 - See LICENSE file for details.
+
+## Contributing
+
+This is an early PoC. Contribution guidelines coming soon.

--- a/examples/MyPlugin/MyPlugin.csproj
+++ b/examples/MyPlugin/MyPlugin.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/MozillaAI.Mcpd.Plugins.Sdk/MozillaAI.Mcpd.Plugins.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/MyPlugin/Program.cs
+++ b/examples/MyPlugin/Program.cs
@@ -1,0 +1,56 @@
+using Google.Protobuf.WellKnownTypes;
+using MozillaAI.Mcpd.Plugins.V1;
+
+/// <summary>
+/// Example plugin implementation that demonstrates basic plugin functionality.
+/// </summary>
+public class MyPlugin : BasePlugin
+{
+    public override Task<Metadata> GetMetadata(Empty request, Grpc.Core.ServerCallContext context)
+    {
+        return Task.FromResult(new Metadata
+        {
+            Name = "my-plugin",
+            Version = "1.0.0",
+            Description = "Example plugin that demonstrates basic functionality"
+        });
+    }
+
+    public override Task<Capabilities> GetCapabilities(Empty request, Grpc.Core.ServerCallContext context)
+    {
+        return Task.FromResult(new Capabilities
+        {
+            Flows = { FlowConstants.FlowRequest }
+        });
+    }
+
+    public override Task<HTTPResponse> HandleRequest(HTTPRequest request, Grpc.Core.ServerCallContext context)
+    {
+        // Example: Add a custom header to all requests.
+        var response = new HTTPResponse
+        {
+            Continue = true,
+            StatusCode = 0,
+            Body = request.Body
+        };
+
+        // Copy existing headers.
+        foreach (var header in request.Headers)
+        {
+            response.Headers.Add(header.Key, header.Value);
+        }
+
+        // Add custom header.
+        response.Headers["X-My-Plugin"] = "processed";
+
+        return Task.FromResult(response);
+    }
+}
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        return await PluginServer.Serve<MyPlugin>(args);
+    }
+}

--- a/examples/MyPlugin/README.md
+++ b/examples/MyPlugin/README.md
@@ -1,0 +1,43 @@
+# MyPlugin Example
+
+Example `mcpd` plugin that demonstrates basic plugin functionality using the .NET SDK.
+
+## What This Example Does
+
+This plugin intercepts HTTP requests and adds a custom header `X-My-Plugin: processed` to demonstrate request processing capabilities.
+
+## Running the Example
+
+```bash
+dotnet run -- --address /tmp/my-plugin.sock --network unix
+```
+
+Or using TCP:
+
+```bash
+dotnet run -- --address localhost:50051 --network tcp
+```
+
+## Key Concepts Demonstrated
+
+- Extending `BasePlugin` to inherit default implementations
+- Implementing `GetMetadata()` to provide plugin information
+- Implementing `GetCapabilities()` to declare request flow support
+- Implementing `HandleRequest()` to process HTTP requests
+- Adding custom headers while preserving existing ones
+
+## Plugin Metadata
+
+| Property | Value |
+|----------|-------|
+| Name | `my-plugin` |
+| Version | `1.0.0` |
+| Description | Example plugin that demonstrates basic functionality |
+| Capabilities | Request flow (`FlowRequest`) |
+
+## Code Structure
+
+The example consists of two classes:
+
+- `MyPlugin`: Extends `BasePlugin` and overrides methods for metadata, capabilities, and request handling
+- `Program`: Entry point that starts the plugin server using `PluginServer.Serve<MyPlugin>()`

--- a/mcpd-plugins-sdk-dotnet.sln
+++ b/mcpd-plugins-sdk-dotnet.sln
@@ -1,0 +1,56 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MozillaAI.Mcpd.Plugins.Sdk", "src\MozillaAI.Mcpd.Plugins.Sdk\MozillaAI.Mcpd.Plugins.Sdk.csproj", "{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyPlugin", "examples\MyPlugin\MyPlugin.csproj", "{E75A1ADA-447B-495A-9BBC-E5A233F901DA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Debug|x64.Build.0 = Debug|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Debug|x86.Build.0 = Debug|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Release|x64.ActiveCfg = Release|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Release|x64.Build.0 = Release|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Release|x86.ActiveCfg = Release|Any CPU
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2}.Release|x86.Build.0 = Release|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Debug|x64.Build.0 = Debug|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Debug|x86.Build.0 = Debug|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Release|x64.ActiveCfg = Release|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Release|x64.Build.0 = Release|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Release|x86.ActiveCfg = Release|Any CPU
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{CE3099F6-A286-4AF2-9829-6EE2B91A17D2} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{E75A1ADA-447B-495A-9BBC-E5A233F901DA} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
+	EndGlobalSection
+EndGlobal

--- a/src/MozillaAI.Mcpd.Plugins.Sdk/BasePlugin.cs
+++ b/src/MozillaAI.Mcpd.Plugins.Sdk/BasePlugin.cs
@@ -1,0 +1,122 @@
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+
+namespace MozillaAI.Mcpd.Plugins.V1;
+
+/// <summary>
+/// BasePlugin provides sensible default implementations for all plugin methods.
+/// Plugin developers can inherit from this class and override only the methods they need.
+/// </summary>
+/// <remarks>
+/// Default behaviors:
+/// <list type="bullet">
+/// <item><description>Configure: no-op</description></item>
+/// <item><description>Stop: no-op</description></item>
+/// <item><description>GetMetadata: returns empty metadata (should be overridden)</description></item>
+/// <item><description>GetCapabilities: returns no flows (should be overridden)</description></item>
+/// <item><description>CheckHealth: returns OK</description></item>
+/// <item><description>CheckReady: returns OK</description></item>
+/// <item><description>HandleRequest: passes through unchanged (continue=true)</description></item>
+/// <item><description>HandleResponse: passes through unchanged (continue=true)</description></item>
+/// </list>
+/// </remarks>
+/// <example>
+/// <code>
+/// public class MyPlugin : BasePlugin
+/// {
+///     public override Task&lt;Metadata&gt; GetMetadata(Empty request, ServerCallContext context)
+///     {
+///         return Task.FromResult(new Metadata
+///         {
+///             Name = "my-plugin",
+///             Version = "1.0.0",
+///             Description = "Example plugin"
+///         });
+///     }
+///
+///     public override Task&lt;HTTPResponse&gt; HandleRequest(HTTPRequest request, ServerCallContext context)
+///     {
+///         // Custom logic here.
+///         return Task.FromResult(new HTTPResponse { Continue = true });
+///     }
+/// }
+/// </code>
+/// </example>
+public class BasePlugin : Plugin.PluginBase
+{
+    /// <summary>
+    /// Configure is a no-op by default.
+    /// </summary>
+    public override Task<Empty> Configure(PluginConfig request, ServerCallContext context)
+    {
+        return Task.FromResult(new Empty());
+    }
+
+    /// <summary>
+    /// Stop is a no-op by default.
+    /// </summary>
+    public override Task<Empty> Stop(Empty request, ServerCallContext context)
+    {
+        return Task.FromResult(new Empty());
+    }
+
+    /// <summary>
+    /// GetMetadata returns empty metadata by default. Plugins should override this.
+    /// </summary>
+    public override Task<Metadata> GetMetadata(Empty request, ServerCallContext context)
+    {
+        return Task.FromResult(new Metadata());
+    }
+
+    /// <summary>
+    /// GetCapabilities returns no flows by default. Plugins should override this.
+    /// </summary>
+    public override Task<Capabilities> GetCapabilities(Empty request, ServerCallContext context)
+    {
+        return Task.FromResult(new Capabilities());
+    }
+
+    /// <summary>
+    /// CheckHealth returns OK by default.
+    /// </summary>
+    public override Task<Empty> CheckHealth(Empty request, ServerCallContext context)
+    {
+        return Task.FromResult(new Empty());
+    }
+
+    /// <summary>
+    /// CheckReady returns OK by default.
+    /// </summary>
+    public override Task<Empty> CheckReady(Empty request, ServerCallContext context)
+    {
+        return Task.FromResult(new Empty());
+    }
+
+    /// <summary>
+    /// HandleRequest passes through the request unchanged with continue=true.
+    /// </summary>
+    public override Task<HTTPResponse> HandleRequest(HTTPRequest request, ServerCallContext context)
+    {
+        return Task.FromResult(new HTTPResponse
+        {
+            Continue = true,
+            StatusCode = 0,
+            Headers = { request.Headers },
+            Body = request.Body
+        });
+    }
+
+    /// <summary>
+    /// HandleResponse passes through the response unchanged with continue=true.
+    /// </summary>
+    public override Task<HTTPResponse> HandleResponse(HTTPResponse request, ServerCallContext context)
+    {
+        return Task.FromResult(new HTTPResponse
+        {
+            Continue = true,
+            StatusCode = request.StatusCode,
+            Headers = { request.Headers },
+            Body = request.Body
+        });
+    }
+}

--- a/src/MozillaAI.Mcpd.Plugins.Sdk/FlowConstants.cs
+++ b/src/MozillaAI.Mcpd.Plugins.Sdk/FlowConstants.cs
@@ -1,0 +1,17 @@
+namespace MozillaAI.Mcpd.Plugins.V1;
+
+/// <summary>
+/// Provides constants for Flow enum values for convenience.
+/// </summary>
+public static class FlowConstants
+{
+    /// <summary>
+    /// FlowRequest indicates the plugin handles incoming HTTP requests.
+    /// </summary>
+    public const Flow FlowRequest = Flow.Request;
+
+    /// <summary>
+    /// FlowResponse indicates the plugin handles outgoing HTTP responses.
+    /// </summary>
+    public const Flow FlowResponse = Flow.Response;
+}

--- a/src/MozillaAI.Mcpd.Plugins.Sdk/MozillaAI.Mcpd.Plugins.Sdk.csproj
+++ b/src/MozillaAI.Mcpd.Plugins.Sdk/MozillaAI.Mcpd.Plugins.Sdk.csproj
@@ -1,0 +1,45 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ProtoVersion>0.0.2</ProtoVersion>
+
+    <PackageId>MozillaAI.Mcpd.Plugins.Sdk</PackageId>
+    <Version>0.0.1</Version>
+    <Authors>Mozilla AI</Authors>
+    <Company>Mozilla AI</Company>
+    <Description>.NET SDK for developing mcpd middleware plugins</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/mozilla-ai/mcpd-plugins-sdk-dotnet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mozilla-ai/mcpd-plugins-sdk-dotnet</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>mcpd;grpc;middleware;plugin</PackageTags>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.29.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.70.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.70.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="$(MSBuildProjectDirectory)/proto/plugin.proto" GrpcServices="Server" ProtoRoot="$(MSBuildProjectDirectory)/proto" />
+  </ItemGroup>
+
+  <Target Name="FetchProto" BeforeTargets="PrepareForBuild">
+    <MakeDir Directories="$(MSBuildProjectDirectory)/proto" />
+    <DownloadFile
+      SourceUrl="https://raw.githubusercontent.com/mozilla-ai/mcpd-proto/v$(ProtoVersion)/plugins/v1/plugin.proto"
+      DestinationFolder="$(MSBuildProjectDirectory)/proto"
+      DestinationFileName="plugin.proto"
+      SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/src/MozillaAI.Mcpd.Plugins.Sdk/MozillaAI.Mcpd.Plugins.Sdk.csproj
+++ b/src/MozillaAI.Mcpd.Plugins.Sdk/MozillaAI.Mcpd.Plugins.Sdk.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <ProtoVersion>0.0.2</ProtoVersion>
+    <ProtoVersion>0.0.3</ProtoVersion>
 
     <PackageId>MozillaAI.Mcpd.Plugins.Sdk</PackageId>
     <Version>0.0.1</Version>

--- a/src/MozillaAI.Mcpd.Plugins.Sdk/PluginServer.cs
+++ b/src/MozillaAI.Mcpd.Plugins.Sdk/PluginServer.cs
@@ -1,0 +1,176 @@
+using System.CommandLine;
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MozillaAI.Mcpd.Plugins.V1;
+
+/// <summary>
+/// PluginServer provides a convenience method for running a plugin server with minimal boilerplate.
+/// It handles command-line argument parsing, network setup, gRPC server creation, and graceful shutdown.
+/// </summary>
+/// <example>
+/// <code>
+/// public class Program
+/// {
+///     public static async Task&lt;int&gt; Main(string[] args)
+///     {
+///         return await PluginServer.Serve&lt;MyPlugin&gt;(args);
+///     }
+/// }
+/// </code>
+/// </example>
+public static class PluginServer
+{
+    /// <summary>
+    /// Starts a gRPC server for the specified plugin implementation.
+    /// </summary>
+    /// <typeparam name="T">The plugin implementation type that inherits from Plugin.PluginBase.</typeparam>
+    /// <param name="args">Command-line arguments.</param>
+    /// <returns>Exit code (0 for success, 1 for error).</returns>
+    public static async Task<int> Serve<T>(string[] args) where T : Plugin.PluginBase, new()
+    {
+        return await Serve(new T(), args);
+    }
+
+    /// <summary>
+    /// Starts a gRPC server for the specified plugin instance.
+    /// </summary>
+    /// <param name="implementation">The plugin implementation instance.</param>
+    /// <param name="args">Command-line arguments.</param>
+    /// <returns>Exit code (0 for success, 1 for error).</returns>
+    public static async Task<int> Serve(Plugin.PluginBase implementation, string[] args)
+    {
+        var addressOption = new Option<string>(
+            name: "--address",
+            description: "gRPC address (socket path for unix, host:port for tcp)")
+        {
+            IsRequired = true
+        };
+
+        var networkOption = new Option<string>(
+            name: "--network",
+            description: "Network type (unix or tcp)",
+            getDefaultValue: () => "unix");
+
+        var rootCommand = new RootCommand("Plugin server for mcpd")
+        {
+            addressOption,
+            networkOption
+        };
+
+        rootCommand.SetHandler(async (address, network) =>
+        {
+            await RunServer(implementation, address, network);
+        }, addressOption, networkOption);
+
+        return await rootCommand.InvokeAsync(args);
+    }
+
+    private static async Task RunServer(Plugin.PluginBase implementation, string address, string network)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+
+        // Configure Kestrel.
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            if (network.Equals("unix", StringComparison.OrdinalIgnoreCase))
+            {
+                // Clean up existing socket file.
+                if (File.Exists(address))
+                {
+                    File.Delete(address);
+                }
+
+                serverOptions.ListenUnixSocket(address, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                });
+            }
+            else if (network.Equals("tcp", StringComparison.OrdinalIgnoreCase))
+            {
+                var parts = address.Split(':');
+                if (parts.Length != 2 || !int.TryParse(parts[1], out var port))
+                {
+                    throw new ArgumentException($"Invalid TCP address format: {address}. Expected host:port");
+                }
+
+                var host = parts[0];
+                var ipAddress = host == "localhost" ? IPAddress.Loopback : IPAddress.Parse(host);
+
+                serverOptions.Listen(ipAddress, port, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                });
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown network type: {network}. Expected 'unix' or 'tcp'");
+            }
+        });
+
+        // Add gRPC services.
+        builder.Services.AddGrpc();
+        builder.Services.AddSingleton(implementation);
+
+        var app = builder.Build();
+
+        // Map gRPC service.
+        app.MapGrpcService<PluginServiceAdapter>();
+
+        Console.WriteLine($"Plugin server listening on {network} {address}");
+
+        try
+        {
+            await app.RunAsync();
+        }
+        finally
+        {
+            // Clean up Unix socket file if it was created.
+            if (network.Equals("unix", StringComparison.OrdinalIgnoreCase) && File.Exists(address))
+            {
+                File.Delete(address);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adapter class to bridge between ASP.NET Core DI and the plugin instance.
+    /// </summary>
+    private class PluginServiceAdapter : Plugin.PluginBase
+    {
+        private readonly Plugin.PluginBase _implementation;
+
+        public PluginServiceAdapter(Plugin.PluginBase implementation)
+        {
+            _implementation = implementation;
+        }
+
+        public override Task<Google.Protobuf.WellKnownTypes.Empty> Configure(PluginConfig request, Grpc.Core.ServerCallContext context)
+            => _implementation.Configure(request, context);
+
+        public override Task<Google.Protobuf.WellKnownTypes.Empty> Stop(Google.Protobuf.WellKnownTypes.Empty request, Grpc.Core.ServerCallContext context)
+            => _implementation.Stop(request, context);
+
+        public override Task<Metadata> GetMetadata(Google.Protobuf.WellKnownTypes.Empty request, Grpc.Core.ServerCallContext context)
+            => _implementation.GetMetadata(request, context);
+
+        public override Task<Capabilities> GetCapabilities(Google.Protobuf.WellKnownTypes.Empty request, Grpc.Core.ServerCallContext context)
+            => _implementation.GetCapabilities(request, context);
+
+        public override Task<Google.Protobuf.WellKnownTypes.Empty> CheckHealth(Google.Protobuf.WellKnownTypes.Empty request, Grpc.Core.ServerCallContext context)
+            => _implementation.CheckHealth(request, context);
+
+        public override Task<Google.Protobuf.WellKnownTypes.Empty> CheckReady(Google.Protobuf.WellKnownTypes.Empty request, Grpc.Core.ServerCallContext context)
+            => _implementation.CheckReady(request, context);
+
+        public override Task<HTTPResponse> HandleRequest(HTTPRequest request, Grpc.Core.ServerCallContext context)
+            => _implementation.HandleRequest(request, context);
+
+        public override Task<HTTPResponse> HandleResponse(HTTPResponse request, Grpc.Core.ServerCallContext context)
+            => _implementation.HandleResponse(request, context);
+    }
+}


### PR DESCRIPTION
## Summary

* Implement .NET SDK following Go SDK patterns and C# conventions
* Add NuGet package metadata for publishing
* Add comprehensive README with usage examples and documentation
* Add example plugin demonstrating basic functionality

## Package Publishing (NuGet)

Prerequisites:

* NuGet account at https://www.nuget.org/
* API key stored secretly

Ready to publish with:

```bash
dotnet pack src/MozillaAI.Mcpd.Plugins.Sdk/MozillaAI.Mcpd.Plugins.Sdk.csproj -c Release

dotnet nuget push src/MozillaAI.Mcpd.Plugins.Sdk/bin/Release/MozillaAI.Mcpd.Plugins.Sdk.0.0.1.nupkg \
    --source https://api.nuget.org/v3/index.json \
    --api-key <our-api-key>
```

Follow-up actions:

* GitHub action to handle releasing based on new releases created in GitHub.