### PR TITLE
Additional log filtering for < INFO

### DIFF
--- a/src/MozillaAI.Mcpd.Plugins.Sdk/PluginServer.cs
+++ b/src/MozillaAI.Mcpd.Plugins.Sdk/PluginServer.cs
@@ -80,6 +80,7 @@ public static class PluginServer
         builder.Logging.AddConsole();
         builder.Logging.AddFilter("Microsoft.AspNetCore", LogLevel.Warning);
         builder.Logging.AddFilter("Microsoft.Extensions", LogLevel.Warning);
+        builder.Logging.AddFilter("Microsoft.Hosting", LogLevel.Warning);
 
         // Configure Kestrel.
         builder.WebHost.ConfigureKestrel((context, serverOptions) =>


### PR DESCRIPTION
Prevents `Microsoft.Hosting` log messages polluting the log at less than `INFO` level.