### PR TITLE
Add structured logging with mcpd-compatible log format

### DIFF
--- a/src/MozillaAI.Mcpd.Plugins.Sdk/BasePlugin.cs
+++ b/src/MozillaAI.Mcpd.Plugins.Sdk/BasePlugin.cs
@@ -1,6 +1,7 @@
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace MozillaAI.Mcpd.Plugins.V1;
 
@@ -46,9 +47,9 @@ namespace MozillaAI.Mcpd.Plugins.V1;
 public class BasePlugin : Plugin.PluginBase
 {
     /// <summary>
-    /// Logger instance for the plugin. Available after SetLogger is called by the SDK.
+    /// Logger instance for the plugin.
     /// </summary>
-    protected ILogger? Logger { get; private set; }
+    protected ILogger Logger { get; private set; } = NullLogger.Instance;
 
     /// <summary>
     /// SetLogger is called by the SDK to provide a logger to the plugin.

--- a/src/MozillaAI.Mcpd.Plugins.Sdk/McpdLogFormatter.cs
+++ b/src/MozillaAI.Mcpd.Plugins.Sdk/McpdLogFormatter.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+
+namespace MozillaAI.Mcpd.Plugins.V1;
+
+/// <summary>
+/// Console formatter that outputs log messages in a format compatible with mcpd's log inference.
+/// </summary>
+internal sealed class McpdLogFormatter : ConsoleFormatter
+{
+    public McpdLogFormatter() : base("mcpd")
+    {
+    }
+
+    public override void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+    {
+        var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+        if (string.IsNullOrEmpty(message))
+        {
+            return;
+        }
+
+        var levelString = GetLevelString(logEntry.LogLevel);
+        textWriter.Write(levelString);
+        textWriter.Write(' ');
+        textWriter.WriteLine(message);
+
+        if (logEntry.Exception != null)
+        {
+            textWriter.WriteLine(logEntry.Exception.ToString());
+        }
+    }
+
+    private static string GetLevelString(LogLevel logLevel)
+    {
+        return logLevel switch
+        {
+            LogLevel.Trace => "[TRACE]",
+            LogLevel.Debug => "[DEBUG]",
+            LogLevel.Information => "[INFO]",
+            LogLevel.Warning => "[WARN]",
+            LogLevel.Error => "[ERROR]",
+            LogLevel.Critical => "[ERROR]",
+            _ => "[INFO]"
+        };
+    }
+}


### PR DESCRIPTION
### Summary

Adds structured logging support to the .NET SDK with automatic log level inference for `mcpd`'s log integration. Implements a custom `McpdLogFormatter` that outputs logs in `[LEVEL] message` format, enabling `mcpd` to properly categorise plugin log messages by severity.

  - Add `McpdLogFormatter` for compatible log output (`[INFO]`, `[WARN]`, `[ERROR]`)
  - Make `Logger` non-nullable in `BasePlugin` with `NullLogger` default
  - Add optional `ILogger` parameter to `PluginServer.Serve()` methods for custom logging
  - Update documentation with logging examples and format specification